### PR TITLE
Do not tflint --init, assume we've done it when baking the image for CI.

### DIFF
--- a/hooks/tflint.sh
+++ b/hooks/tflint.sh
@@ -7,8 +7,9 @@ set -e
 # workaround to allow GitHub Desktop to work, add this (hopefully harmless) setting here.
 export PATH=$PATH:/usr/local/bin
 
-# Install any plugins defined in .tflint.hcl
-tflint --init
+# Note that we expect the environment this runs in to already have run `tflint --init`!
+# During CI, the image should already have the desired plugins cached, so we're not blasting GitHub
+# too many times.
 
 for file in "$@"; do
   tflint $file


### PR DESCRIPTION
This removes what is an extra `tflint --init` for us, and should avoid hitting rate limits and such.