### PR TITLE
Pick up .tflint.hcl from closest parent

### DIFF
--- a/hooks/tflint.sh
+++ b/hooks/tflint.sh
@@ -11,6 +11,20 @@ export PATH=$PATH:/usr/local/bin
 # During CI, the image should already have the desired plugins cached, so we're not blasting GitHub
 # too many times.
 
-for file in "$@"; do
-  tflint $file
+for file in "${@:2}"; do
+  CMD="tflint"
+
+  # Find first tflint config in folder hierarchy
+  CONFIG_PATH=$(readlink -e ${file%/*})
+  while [[ "$CONFIG_PATH" != "" && ! -e "$CONFIG_PATH/.tflint.hcl" ]]; do
+    CONFIG_PATH="${CONFIG_PATH%/*}"
+  done
+
+  # If .tflint is found, pass that to command
+  if [ "$CONFIG_PATH" != "" ]; then
+    CONFIG_FILE="$CONFIG_PATH/.tflint.hcl"
+    CMD="tflint -c $CONFIG_FILE"
+  fi
+
+  TFLINT_LOG=debug $CMD $file
 done

--- a/hooks/tflint.sh
+++ b/hooks/tflint.sh
@@ -11,7 +11,7 @@ export PATH=$PATH:/usr/local/bin
 # During CI, the image should already have the desired plugins cached, so we're not blasting GitHub
 # too many times.
 
-for file in "${@:2}"; do
+for file in "$@"; do
   CMD="tflint"
 
   # Find first tflint config in folder hierarchy


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Allows tflint pre-commit to pick up the .tflint.hcl file from the closest parent of each file passed into the pre-commit. The default behavior is to only check the working directory - that's fine for CI, but running pre-commit locally from a folder that's not root will cause the config file to be ignored.

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [ ] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [ ] Update the docs.
- [X] Keep the changes backward compatible where possible.
- [X] Run the pre-commit checks successfully.
- [X] Run the relevant tests successfully.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.